### PR TITLE
Delete duplicate finite state machine JUnit test cases and revise method's name

### DIFF
--- a/core/src/test/java/io/questdb/griffin/InsertTest.java
+++ b/core/src/test/java/io/questdb/griffin/InsertTest.java
@@ -480,31 +480,6 @@ public class InsertTest extends AbstractGriffinTest {
         });
     }
 
-    public void createTab() throws SqlException {
-        compiler.compile("create table tab (id int, text string)", sqlExecutionContext);
-    }
-
-    @Test
-    public void testQuestDBStateMachineAtEmptyTableState() throws Exception {
-        assertMemoryLeak(() -> {
-                    createTab();
-                    assertSql("'tab'", "id\ttext\n");
-                }
-        );
-    }
-
-    @Test
-    public void testQuestDBStateMachineAtNonEmptyTableStateInsert() throws Exception {
-        assertMemoryLeak(
-                () -> {
-                    createTab();
-                    executeInsert("insert into tab values (1, 'test')");
-                    assertSql("'tab'", "id\ttext\n" +
-                            "1\ttest\n");
-                }
-        );
-    }
-
     @Test
     public void testInsertISODateStringToDesignatedTimestampColumn() throws Exception {
         final String expected = "seq\tts\n" +

--- a/core/src/test/java/io/questdb/griffin/TruncateTest.java
+++ b/core/src/test/java/io/questdb/griffin/TruncateTest.java
@@ -128,32 +128,6 @@ public class TruncateTest extends AbstractGriffinTest {
     }
 
     @Test
-    public void testQuestDBStateMachineAtEmptyTableStateTruncate() throws Exception {
-        assertMemoryLeak(() -> {
-            try {
-                Assert.assertNull(compiler.compile("truncate table 'tab'", sqlExecutionContext));
-                Assert.fail();
-            } catch (SqlException e) {
-                Assert.assertEquals(15, e.getPosition());
-                TestUtils.assertContains(e.getFlyweightMessage(), "table does not exist [table=tab]");
-            }
-        });
-    }
-
-    @Test
-    public void testQuestDBStateMachineAtNonEmptyTableStateTruncate() throws Exception {
-        assertMemoryLeak(() -> {
-            try {
-                Assert.assertNull(compiler.compile("truncate table 'tab'", sqlExecutionContext));
-                assertSql("'tab'", "id\ttext\n");
-            } catch (SqlException e) {
-                Assert.assertEquals(15, e.getPosition());
-                TestUtils.assertContains(e.getFlyweightMessage(), "table does not exist [table=tab]");
-            }
-        });
-    }
-
-    @Test
     public void testHappyPath() throws Exception {
         assertMemoryLeak(
                 () -> {

--- a/core/src/test/java/io/questdb/griffin/UpdateTest.java
+++ b/core/src/test/java/io/questdb/griffin/UpdateTest.java
@@ -77,30 +77,6 @@ public class UpdateTest extends AbstractGriffinTest {
         testInsertAfterFailed(true);
     }
 
-    public void createTab() throws SqlException {
-        compiler.compile("create table tab (id int, text string)", sqlExecutionContext);
-    }
-
-    @Test
-    public void testQuestDBStateMachineAtEmptyTableStateUpdate() throws Exception {
-        assertMemoryLeak(() -> {
-            createTab();
-            executeUpdate("update tab set text = 'test2' where text = 'test'");
-            assertSql("'tab'", "id\ttext\n");
-        });
-    }
-
-    @Test
-    public void testQuestDBStateMachineAtNonEmptyTableStateUpdate() throws Exception {
-        assertMemoryLeak(() -> {
-            createTab();
-            executeInsert("insert into tab values (1, 'test');");
-            executeUpdate("update tab set text = 'test2' where text = 'test'");
-            assertSql("'tab'", "id\ttext\n" +
-                    "1\ttest2\n");
-        });
-    }
-
     @Test
     public void testInsertAfterUpdate() throws Exception {
         assertMemoryLeak(() -> {

--- a/core/src/test/java/testingdebugging/FSMTest.java
+++ b/core/src/test/java/testingdebugging/FSMTest.java
@@ -46,7 +46,6 @@ public class FSMTest extends AbstractGriffinTest {
 
     // TODO our tests of Insert Data
     // state transition 1 : empty table -> operation: insert data -> non-empty table
-    // state transition 2 : non-empty table -> operation: insert data -> non-empty table
 
     public void createTab() throws SqlException {
         compiler.compile("create table tab (id int, text string)", sqlExecutionContext);
@@ -70,7 +69,7 @@ public class FSMTest extends AbstractGriffinTest {
     }
 
     @Test
-    public void testQuestDBStateMachineAtNonEmptyTableStateInsert() throws Exception {
+    public void testQuestDBStateMachineAtEmptyTableStateInsert() throws Exception {
         assertMemoryLeak(
                 () -> {
                     createTab();


### PR DESCRIPTION
1. Delete duplicate finite state machine JUnit test cases in InsertTest.java, UpdateTest.java, TruncateTest.java
2. Revise method name from #testQuestDBStateMachineAtNonEmptyTableStateInsert to #testQuestDBStateMachineAtEmptyTableStateInsert in FSMTest.java, and edit the comments